### PR TITLE
fix: preserve attachment filenames and enrich activity details

### DIFF
--- a/src/controllers/cardController.js
+++ b/src/controllers/cardController.js
@@ -139,6 +139,23 @@ const removeAttachment = async (req, res, next) => {
   }
 }
 
+const downloadAttachment = async (req, res, next) => {
+  try {
+    const { attachment, buffer } = await cardService.downloadAttachment(
+      req.params.id,
+      req.params.attachmentId,
+      req.authorizedBoard
+    )
+
+    res.attachment(attachment.name)
+    res.type(attachment.mimeType)
+    res.setHeader('Cache-Control', 'private, no-store')
+    res.status(StatusCodes.OK).send(buffer)
+  } catch (error) {
+    next(error)
+  }
+}
+
 export const cardController = {
   createNew,
   update,
@@ -147,5 +164,6 @@ export const cardController = {
   getArchivedByBoardId,
   move,
   addAttachment,
-  removeAttachment
+  removeAttachment,
+  downloadAttachment
 }

--- a/src/middlewares/boardAuthorizationMiddleware.js
+++ b/src/middlewares/boardAuthorizationMiddleware.js
@@ -149,6 +149,7 @@ export const boardAuthorizationMiddleware = {
     resolveCardParam,
     canEditBoardContent
   ),
+  requireBoardAccessByCard: authorize(resolveCardParam, canAccessBoard),
   requireBoardContentEditorForCardMove: authorize(
     resolveCardMove,
     canEditBoardContent

--- a/src/models/activityModel.js
+++ b/src/models/activityModel.js
@@ -8,6 +8,9 @@ import {
 import { OBJECT_ID_RULE, OBJECT_ID_RULE_MESSAGE } from '~/utils/validators'
 import { pagingSkipValue } from '~/utils/algorithms'
 import { userModel } from '~/models/userModel'
+import { cardModel } from '~/models/cardModel'
+import { columnModel } from '~/models/columnModel'
+import { boardModel } from '~/models/boardModel'
 
 const ACTIVITY_COLLECTION_NAME = 'activities'
 const ACTIVITY_COLLECTION_SCHEMA = Joi.object({
@@ -69,7 +72,96 @@ const findByBoardId = async (boardId, page, itemsPerPage) => {
                 pipeline: [{ $project: userModel.PUBLIC_USER_PROJECTION }]
               }
             },
-            { $set: { actor: { $first: '$actor' } } }
+            {
+              $set: {
+                targetUserObjectId: {
+                  $convert: {
+                    input: {
+                      $ifNull: [
+                        '$metadata.targetUserId',
+                        {
+                          $ifNull: [
+                            '$metadata.memberId',
+                            '$metadata.inviteeId'
+                          ]
+                        }
+                      ]
+                    },
+                    to: 'objectId',
+                    onError: null,
+                    onNull: null
+                  }
+                }
+              }
+            },
+            {
+              $lookup: {
+                from: userModel.USER_COLLECTION_NAME,
+                localField: 'targetUserObjectId',
+                foreignField: '_id',
+                as: 'targetUser',
+                pipeline: [{
+                  $project: {
+                    _id: 1,
+                    userName: 1,
+                    displayName: 1,
+                    avatar: 1
+                  }
+                }]
+              }
+            },
+            {
+              $lookup: {
+                from: cardModel.CARD_COLLECTION_NAME,
+                localField: 'entityId',
+                foreignField: '_id',
+                as: 'cardEntity',
+                pipeline: [{ $project: { title: 1 } }]
+              }
+            },
+            {
+              $lookup: {
+                from: columnModel.COLUMN_COLLECTION_NAME,
+                localField: 'entityId',
+                foreignField: '_id',
+                as: 'columnEntity',
+                pipeline: [{ $project: { title: 1 } }]
+              }
+            },
+            {
+              $lookup: {
+                from: boardModel.BOARD_COLLECTION_NAME,
+                localField: 'entityId',
+                foreignField: '_id',
+                as: 'boardEntity',
+                pipeline: [{ $project: { title: 1 } }]
+              }
+            },
+            {
+              $set: {
+                actor: { $first: '$actor' },
+                targetUser: { $first: '$targetUser' },
+                entityTitle: {
+                  $ifNull: [
+                    { $first: '$cardEntity.title' },
+                    {
+                      $ifNull: [
+                        { $first: '$columnEntity.title' },
+                        { $first: '$boardEntity.title' }
+                      ]
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              $unset: [
+                'targetUserObjectId',
+                'cardEntity',
+                'columnEntity',
+                'boardEntity'
+              ]
+            }
           ],
           total: [{ $count: 'count' }]
         }

--- a/src/providers/CloudinaryProvider.js
+++ b/src/providers/CloudinaryProvider.js
@@ -29,7 +29,45 @@ const streamUpload = (fileBuffer, folderName, options = {}) => {
 const destroy = async (publicId, resourceType = 'image') =>
   await cloudinaryV2.uploader.destroy(publicId, { resource_type: resourceType })
 
+export const isTrustedCloudinaryUrl = (url) => {
+  try {
+    const parsedUrl = new URL(url)
+    return parsedUrl.protocol === 'https:' &&
+      parsedUrl.hostname === 'res.cloudinary.com'
+  } catch {
+    return false
+  }
+}
+
+const downloadResource = async (url, maxBytes = 10 * 1024 * 1024) => {
+  if (!isTrustedCloudinaryUrl(url)) {
+    throw new Error('Refusing to download an untrusted attachment URL.')
+  }
+
+  const abortController = new AbortController()
+  const timeoutId = setTimeout(() => abortController.abort(), 15_000)
+  try {
+    const response = await fetch(url, { signal: abortController.signal })
+    if (!response.ok) {
+      throw new Error(`Cloud attachment returned HTTP ${response.status}.`)
+    }
+
+    const declaredSize = Number(response.headers.get('content-length'))
+    if (Number.isFinite(declaredSize) && declaredSize > maxBytes) {
+      throw new Error('Cloud attachment exceeds its allowed size.')
+    }
+    const buffer = Buffer.from(await response.arrayBuffer())
+    if (buffer.length > maxBytes) {
+      throw new Error('Cloud attachment exceeds its allowed size.')
+    }
+    return buffer
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
 export const CloudinaryProvider = {
   streamUpload,
-  destroy
+  destroy,
+  downloadResource
 }

--- a/src/routes/v1/cardRoute.js
+++ b/src/routes/v1/cardRoute.js
@@ -56,6 +56,12 @@ Router.route('/:id/attachments').post(
   cardController.addAttachment
 )
 
+Router.route('/:id/attachments/:attachmentId/download').get(
+  authMiddleware.isAuthorized,
+  boardAuthorizationMiddleware.requireBoardAccessByCard,
+  cardController.downloadAttachment
+)
+
 Router.route('/:id/attachments/:attachmentId').delete(
   authMiddleware.isAuthorized,
   boardAuthorizationMiddleware.requireBoardContentEditorByCard,

--- a/src/services/cardService.js
+++ b/src/services/cardService.js
@@ -273,8 +273,11 @@ const update = async (
       const reaction = reactions.find(
         (item) => item.emoji === updateData.commentReaction.emoji
       )
+      let reactionAction = 'ADDED'
       if (reaction) {
-        reaction.userIds = reaction.userIds.includes(userInfo._id)
+        const alreadyReacted = reaction.userIds.includes(userInfo._id)
+        reactionAction = alreadyReacted ? 'REMOVED' : 'ADDED'
+        reaction.userIds = alreadyReacted
           ? reaction.userIds.filter((userId) => userId !== userInfo._id)
           : [...reaction.userIds, userInfo._id]
       } else {
@@ -290,7 +293,11 @@ const update = async (
         session
       )
       activityAction = ACTIVITY_ACTIONS.CARD_COMMENT_REACTED
-      activityMetadata = { commentId: comment._id }
+      activityMetadata = {
+        commentId: comment._id,
+        emoji: updateData.commentReaction.emoji,
+        reactionAction
+      }
     } else if (updateData.incommingMemberInfo) {
       const targetUserId = updateData.incommingMemberInfo.userId
       const boardUserIds = getBoardUserIds(authorizedBoard)
@@ -540,7 +547,12 @@ const move = async (cardId, targetColumnId, userInfo, authorizedBoard) =>
         action: ACTIVITY_ACTIONS.CARD_MOVED,
         entityType: ACTIVITY_ENTITY_TYPES.CARD,
         entityId: cardId,
-        metadata: { fromColumnId: previousColumnId, toColumnId: targetColumnId }
+        metadata: {
+          fromColumnId: previousColumnId,
+          fromColumnTitle: previousColumn.title,
+          toColumnId: targetColumnId,
+          toColumnTitle: nextColumn.title
+        }
       },
       session
     )

--- a/src/services/cardService.js
+++ b/src/services/cardService.js
@@ -660,6 +660,42 @@ const removeAttachment = async (
   return updatedCard
 }
 
+const downloadAttachment = async (
+  cardId,
+  attachmentId,
+  authorizedBoard
+) => {
+  const card = await cardModel.findOneById(cardId)
+  if (!card || card.boardId.toString() !== authorizedBoard._id.toString()) {
+    throw new ApiError(StatusCodes.NOT_FOUND, 'Card not found!')
+  }
+  const attachment = card.attachments?.find(
+    (item) => item._id === attachmentId
+  )
+  if (!attachment) {
+    throw new ApiError(StatusCodes.NOT_FOUND, 'Attachment not found!')
+  }
+
+  try {
+    const buffer = await CloudinaryProvider.downloadResource(
+      attachment.url,
+      attachment.size
+    )
+    return { attachment, buffer }
+  } catch (error) {
+    logger.error('Failed to download card attachment', {
+      cardId,
+      attachmentId,
+      publicId: attachment.publicId,
+      error: error.message
+    })
+    throw new ApiError(
+      StatusCodes.BAD_GATEWAY,
+      'Attachment is temporarily unavailable.'
+    )
+  }
+}
+
 export const cardService = {
   createNew,
   update,
@@ -668,5 +704,6 @@ export const cardService = {
   getArchivedByBoardId,
   move,
   addAttachment,
-  removeAttachment
+  removeAttachment,
+  downloadAttachment
 }

--- a/src/services/columnService.js
+++ b/src/services/columnService.js
@@ -116,7 +116,8 @@ const deleteItem = async (columnId, actorId) => {
           actorId,
           action: ACTIVITY_ACTIONS.COLUMN_DELETED,
           entityType: ACTIVITY_ENTITY_TYPES.COLUMN,
-          entityId: columnId
+          entityId: columnId,
+          metadata: { entityTitle: targetColumn.title }
         },
         session
       )

--- a/tests/attachmentUpload.test.js
+++ b/tests/attachmentUpload.test.js
@@ -3,6 +3,9 @@ const assert = require('node:assert/strict')
 const {
   createFileFilter
 } = require('../build/src/middlewares/multerUploadMiddleware')
+const {
+  isTrustedCloudinaryUrl
+} = require('../build/src/providers/CloudinaryProvider')
 
 const runFilter = (allowedTypes, mimetype) =>
   new Promise((resolve, reject) => {
@@ -25,4 +28,24 @@ test('rejects a disallowed attachment MIME type', async () => {
     runFilter(['application/pdf'], 'application/x-msdownload'),
     /Rejected attachment/
   )
+})
+
+test('downloads attachments only from the trusted Cloudinary delivery host', () => {
+  assert.equal(
+    isTrustedCloudinaryUrl(
+      'https://res.cloudinary.com/demo/raw/upload/card/report.pdf'
+    ),
+    true
+  )
+  assert.equal(
+    isTrustedCloudinaryUrl('http://res.cloudinary.com/demo/report.pdf'),
+    false
+  )
+  assert.equal(
+    isTrustedCloudinaryUrl(
+      'https://res.cloudinary.com.example.com/demo/report.pdf'
+    ),
+    false
+  )
+  assert.equal(isTrustedCloudinaryUrl('not-a-url'), false)
 })

--- a/tests/phase0Integration.test.js
+++ b/tests/phase0Integration.test.js
@@ -509,6 +509,7 @@ test('validates phase one card invariants and attachment lifecycle', {
 
   const originalUpload = modules.CloudinaryProvider.streamUpload
   const originalDestroy = modules.CloudinaryProvider.destroy
+  const originalDownload = modules.CloudinaryProvider.downloadResource
   const destroyed = []
   modules.CloudinaryProvider.streamUpload = async () => ({
     secure_url: 'https://res.cloudinary.com/test/raw/upload/test.txt',
@@ -518,6 +519,14 @@ test('validates phase one card invariants and attachment lifecycle', {
   modules.CloudinaryProvider.destroy = async (...args) => {
     destroyed.push(args)
     return { result: 'ok' }
+  }
+  modules.CloudinaryProvider.downloadResource = async (url, maxBytes) => {
+    assert.equal(
+      url,
+      'https://res.cloudinary.com/test/raw/upload/test.txt'
+    )
+    assert.equal(maxBytes, Buffer.byteLength('phase one attachment'))
+    return Buffer.from('phase one attachment')
   }
   try {
     const form = new FormData()
@@ -537,6 +546,32 @@ test('validates phase one card invariants and attachment lifecycle', {
     assert.equal(attachment.mimeType, 'text/plain')
     assert.equal(attachment.uploadedBy, fixture.ids.member.toString())
 
+    const outsiderDownload = await fetch(
+      `${baseUrl}/V1/cards/${cardId}/attachments/${attachment._id}/download`,
+      {
+        headers: {
+          Cookie: `${AUTH_COOKIE_NAMES.access}=${fixture.users.outsider.token}`
+        }
+      }
+    )
+    assert.equal(outsiderDownload.status, 403)
+
+    const download = await fetch(
+      `${baseUrl}/V1/cards/${cardId}/attachments/${attachment._id}/download`,
+      {
+        headers: {
+          Cookie: `${AUTH_COOKIE_NAMES.access}=${fixture.users.viewer.token}`
+        }
+      }
+    )
+    assert.equal(download.status, 200)
+    assert.match(
+      download.headers.get('content-disposition'),
+      /^attachment; filename="phase-one\.txt"/
+    )
+    assert.match(download.headers.get('content-type'), /^text\/plain/)
+    assert.equal(await download.text(), 'phase one attachment')
+
     const removed = await request(
       `/cards/${cardId}/attachments/${attachment._id}`,
       {
@@ -550,6 +585,7 @@ test('validates phase one card invariants and attachment lifecycle', {
   } finally {
     modules.CloudinaryProvider.streamUpload = originalUpload
     modules.CloudinaryProvider.destroy = originalDestroy
+    modules.CloudinaryProvider.downloadResource = originalDownload
   }
 
   const copied = await request(`/cards/${cardId}/copy`, {
@@ -753,7 +789,9 @@ test('keeps cross-column moves atomic and records precise activity', { skip: ski
   })
   assert.deepEqual(activity.metadata, {
     fromColumnId: previous._id,
-    toColumnId: next._id
+    fromColumnTitle: previous.title,
+    toColumnId: next._id,
+    toColumnTitle: next.title
   })
 })
 
@@ -972,6 +1010,21 @@ test('records every current mutation and creates the required indexes', { skip: 
     assert.equal(update.status, 200)
   }
 
+  const cardWithComment = await database.collection('cards').findOne({
+    _id: new ObjectId(cardId)
+  })
+  const reacted = await request(`/cards/${cardId}`, {
+    token: fixture.users.member.token,
+    method: 'PUT',
+    body: {
+      commentReaction: {
+        commentId: cardWithComment.comments[0]._id,
+        emoji: '👍'
+      }
+    }
+  })
+  assert.equal(reacted.status, 200)
+
   const boardUpdate = await request(`/boards/${fixture.boardId}`, {
     token: fixture.users.admin.token,
     method: 'PUT',
@@ -1059,6 +1112,7 @@ test('records every current mutation and creates the required indexes', { skip: 
     'CARD_CREATED',
     'CARD_UPDATED',
     'CARD_COMMENTED',
+    'CARD_COMMENT_REACTED',
     'CARD_MEMBER_ADDED',
     'CARD_MEMBER_REMOVED',
     'INVITATION_CREATED',
@@ -1067,6 +1121,22 @@ test('records every current mutation and creates the required indexes', { skip: 
   ]) {
     assert.ok(actions.has(expected), `Missing activity action ${expected}`)
   }
+
+  const activityResponse = await request(
+    `/boards/${fixture.boardId}/activities?page=1&itemsPerPage=100`,
+    { token: fixture.users.viewer.token }
+  )
+  assert.equal(activityResponse.status, 200)
+  const reactionActivity = activityResponse.body.activities.find(
+    (activity) => activity.action === 'CARD_COMMENT_REACTED'
+  )
+  assert.equal(reactionActivity.entityTitle, 'Updated activity card')
+  assert.equal(reactionActivity.metadata.emoji, '👍')
+  assert.equal(reactionActivity.metadata.reactionAction, 'ADDED')
+  const memberActivity = activityResponse.body.activities.find(
+    (activity) => activity.action === 'CARD_MEMBER_ADDED'
+  )
+  assert.equal(memberActivity.targetUser.displayName, 'viewer')
 
   const indexExpectations = {
     users: ['users_email_unique', 'users_password_reset_token_unique'],


### PR DESCRIPTION
## Summary

This PR fixes attachment downloads and improves board activity data returned by the API.

## Root cause

- Attachment URLs pointed directly to cross-origin Cloudinary resources, so browsers relied on Cloudinary response metadata instead of the original uploaded filename.
- Activity records exposed action enums but did not provide enough related entity and user context for the frontend to create clear messages.
- Comment reaction events did not distinguish between adding and removing a reaction.

## Changes

### Attachment downloads

- Add an authenticated card attachment download endpoint.
- Verify that the requester has access to the attachment's board.
- Proxy trusted Cloudinary resources and return the original filename through `Content-Disposition`.
- Restrict remote downloads to HTTPS Cloudinary delivery URLs.
- Add download timeout and size validation.
- Return `403` for users outside the board and `404` for missing cards or attachments.

### Activity details

- Enrich paginated activity results with actor, target user, and card/column/board titles.
- Record emoji and add/remove state for comment reactions.
- Record source and destination column titles for card moves.
- Preserve deleted column titles in activity metadata.
- Limit target-user projection to public profile fields.

### Tests

- Add trusted Cloudinary URL tests.
- Cover authenticated attachment downloads, original filename/MIME type, board-member access, and outsider rejection.
- Cover enriched reaction, member, and moved-card activity metadata.

## Impact

Board members can download attachments with their original name and extension. The frontend receives enough structured activity data to display readable and specific event messages without exposing internal action identifiers.

## Validation

- `yarn lint`
- `yarn test`
- Babel production build: 63 files compiled
- Unit tests: 32 passed, 0 failed
- 9 MongoDB integration groups are conditionally skipped when `MONGODB_TEST_URI` is unavailable. A forced run was attempted but Atlas DNS returned `querySrv ETIMEOUT` before test setup.

## Related frontend change

- https://github.com/dhoangvu1811/Trello-Web/pull/58